### PR TITLE
[ARV-115] 메인 페이지 기능 구현

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-VITE_REST_API_KEY=c8c9d6bab40971123f44a3e29677e1e7
-VITE_REDIRECT_URI=http://localhost:3000/signup

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ dist-ssr
 
 
 # Environment Variables
-.env
+
 .env.local
 .env.development
 .env.production

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ dist-ssr
 
 
 # Environment Variables
-
+.env
 .env.local
 .env.development
 .env.production

--- a/src/api/concerts.ts
+++ b/src/api/concerts.ts
@@ -2,9 +2,14 @@ import { endPoint } from 'constants/endPoint';
 import { publicAxios } from 'utils';
 
 const getConcertList = async (region: string, sortDirection: string, pageSize: number) => {
-  const response = await publicAxios.get(
-    endPoint.GET_CONCERT_LIST(region, sortDirection, pageSize)
-  );
+  const params = new URLSearchParams();
+
+  if (region !== '전체') params.append('region', region);
+
+  params.append('sortDirection', sortDirection);
+  params.append('PageSize', pageSize.toString());
+
+  const response = await publicAxios.get(`${endPoint.GET_CONCERT_LIST}?${params.toString()}`);
   return response;
 };
 

--- a/src/api/concerts.ts
+++ b/src/api/concerts.ts
@@ -1,0 +1,11 @@
+import { endPoint } from 'constants/endPoint';
+import { publicAxios } from 'utils';
+
+const getConcertList = async (region: string, sortDirection: string, pageSize: number) => {
+  const response = await publicAxios.get(
+    endPoint.GET_CONCERT_LIST(region, sortDirection, pageSize)
+  );
+  return response;
+};
+
+export { getConcertList };

--- a/src/api/concerts.ts
+++ b/src/api/concerts.ts
@@ -1,13 +1,23 @@
 import { endPoint } from 'constants/endPoint';
 import { publicAxios } from 'utils';
 
-const getConcertList = async (region: string, sortDirection: string, pageSize: number) => {
+const getConcertList = async (
+  region: string,
+  sortDirection: string,
+  searchAfter?: [number, string] | null
+) => {
+  const PAGE_SIZE = 7;
   const params = new URLSearchParams();
 
   if (region !== '전체') params.append('region', region);
 
   params.append('sortDirection', sortDirection);
-  params.append('PageSize', pageSize.toString());
+  params.append('PageSize', PAGE_SIZE.toString());
+
+  if (searchAfter) {
+    params.append('searchAfter1', searchAfter[0].toString());
+    params.append('searchAfter2', searchAfter[1]);
+  }
 
   const response = await publicAxios.get(`${endPoint.GET_CONCERT_LIST}?${params.toString()}`);
   return response;

--- a/src/constants/endPoint.ts
+++ b/src/constants/endPoint.ts
@@ -30,7 +30,8 @@ export const endPoint = {
   GET_CONCERT_SEARCH: '/search/concert',
   GET_CONCERT_SEARCH_LIST: '/search/concert/list',
 
-  GET_CONCERT_LIST: '/concerts/list',
+  GET_CONCERT_LIST: (region: string, sortDirection: string, pageSize: number) =>
+    `/concerts/list?region=${encodeURIComponent(region)}&sortDirection=${sortDirection}&PageSize=${pageSize}`,
   GET_CONCERT_DETAIL: (concertId: string) => `/concerts/${concertId}`,
 
   SEARCH_ARTISTS: '/artists/search',

--- a/src/constants/endPoint.ts
+++ b/src/constants/endPoint.ts
@@ -30,8 +30,7 @@ export const endPoint = {
   GET_CONCERT_SEARCH: '/search/concert',
   GET_CONCERT_SEARCH_LIST: '/search/concert/list',
 
-  GET_CONCERT_LIST: (region: string, sortDirection: string, pageSize: number) =>
-    `/concerts/list?region=${encodeURIComponent(region)}&sortDirection=${sortDirection}&PageSize=${pageSize}`,
+  GET_CONCERT_LIST: '/concerts/list',
   GET_CONCERT_DETAIL: (concertId: string) => `/concerts/${concertId}`,
 
   SEARCH_ARTISTS: '/artists/search',

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,1 +1,1 @@
-export const API_URL = import.meta.env.API_URL;
+export const API_URL = import.meta.env.VITE_API_URL;

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const defaultOptions = {
+  rootMargin: '1px',
+  threshold: 0.1,
+};
+
+export const useIntersectionObserver = (onIntersect: () => void) => {
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+      if (entry.isIntersecting) {
+        onIntersect();
+      }
+    },
+    [onIntersect]
+  );
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+
+    const observer = new IntersectionObserver(handleObserver, defaultOptions);
+
+    observer.observe(target);
+
+    return () => observer.unobserve(target);
+  }, [handleObserver]);
+
+  return targetRef;
+};

--- a/src/pages/concert/Concert.tsx
+++ b/src/pages/concert/Concert.tsx
@@ -3,11 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { LuCalendar } from 'react-icons/lu';
 
-import ListItem, { sortValue } from './components/ListItem';
-import type { Result } from './type';
+import FilterChips from './components/FilterChips';
+import ListItem from './components/ListItem';
+import type { FilterCategory, Result } from './type';
 
 import { getConcertList } from 'api/concerts';
-import FilterChip from 'components/chips/FilterChip';
 import { useModalStore } from 'stores';
 import { BodyRegularText, ChipText, HeaderText, SmallText } from 'styles/Typography';
 
@@ -36,7 +36,7 @@ const Concert = () => {
     setSelectedDirection(sortDirection);
   };
 
-  const handleModalOpen = (title: '지역' | '정렬', onSelect: (value: string) => void) => {
+  const handleModalOpen = (title: FilterCategory, onSelect: (value: string) => void) => {
     openModal('bottomSheet', 'list', <ListItem onSelect={onSelect} title={title} />);
   };
 
@@ -46,14 +46,13 @@ const Concert = () => {
         <HeaderText>예정 공연</HeaderText>
         <BodyRegularText>ALLREVA에서 예정된 공연들을 손쉽게 확인해보세요!</BodyRegularText>
       </ExpectedConcert>
-      <Filter>
-        <FilterChip isActive={false} onClick={() => handleModalOpen('지역', handleRegionSelect)}>
-          {selectedRegion}
-        </FilterChip>
-        <FilterChip isActive={false} onClick={() => handleModalOpen('정렬', handleDirectionSelect)}>
-          {sortValue[selectedDirection as keyof typeof sortValue]}
-        </FilterChip>
-      </Filter>
+      <FilterChips
+        handleDirectionSelect={handleDirectionSelect}
+        handleModalOpen={handleModalOpen}
+        handleRegionSelect={handleRegionSelect}
+        selectedDirection={selectedDirection}
+        selectedRegion={selectedRegion}
+      />
       <ConcertList>
         {data?.concertThumbnails.map((concert) => (
           <ConcertItem key={concert.id}>
@@ -95,12 +94,6 @@ const ExpectedConcert = styled.div`
   p {
     color: ${({ theme }) => theme.colors.dark[500]};
   }
-`;
-
-const Filter = styled.div`
-  display: flex;
-  gap: 12px;
-  padding: 2.4rem 2.4rem 0 2.4rem;
 `;
 
 const ConcertList = styled.div`

--- a/src/pages/concert/Concert.tsx
+++ b/src/pages/concert/Concert.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useState } from 'react';
+import { PiPencilSimpleLineBold } from 'react-icons/pi';
 
 import ConcertItem from './components/ConcertItem';
 import FilterChips from './components/FilterChips';
@@ -8,6 +9,7 @@ import ListItem from './components/ListItem';
 import type { FilterCategory, Result } from './type';
 
 import { getConcertList } from 'api/concerts';
+import IconButton from 'components/buttons/IconButton';
 import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
 import { useModalStore } from 'stores';
 import { BodyRegularText, HeaderText } from 'styles/Typography';
@@ -24,12 +26,10 @@ const Concert = () => {
       const {
         data: { result },
       } = await getConcertList(selectedRegion, selectedDirection, pageParam as Param);
-      console.log('searchAfter 값:', result.searchAfter);
       return result;
     },
     initialPageParam: null,
     getNextPageParam: (lastPage) => {
-      console.log('searchAfter 값:', lastPage.searchAfter);
       return lastPage.searchAfter || undefined;
     },
   });
@@ -77,6 +77,13 @@ const Concert = () => {
         )}
       </ConcertList>
       <div ref={targetRef} />
+      <FloatingAside>
+        <FloatingButton>
+          <IconButton isDisabled={false} size="medium">
+            <PiPencilSimpleLineBold size={20} />
+          </IconButton>
+        </FloatingButton>
+      </FloatingAside>
     </ConcertContainer>
   );
 };
@@ -104,6 +111,21 @@ const ExpectedConcert = styled.div`
 const ConcertList = styled.div`
   width: 100%;
   padding: 2.4rem;
+`;
+
+const FloatingAside = styled.aside`
+  max-width: ${({ theme }) => theme.maxWidth};
+  margin: 0 auto;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
+
+const FloatingButton = styled.div`
+  position: absolute;
+  bottom: 8rem;
+  right: 2rem;
 `;
 
 export default Concert;

--- a/src/pages/concert/Concert.tsx
+++ b/src/pages/concert/Concert.tsx
@@ -1,15 +1,15 @@
 import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { LuCalendar } from 'react-icons/lu';
 
+import ConcertItem from './components/ConcertItem';
 import FilterChips from './components/FilterChips';
 import ListItem from './components/ListItem';
 import type { FilterCategory, Result } from './type';
 
 import { getConcertList } from 'api/concerts';
 import { useModalStore } from 'stores';
-import { BodyRegularText, ChipText, HeaderText, SmallText } from 'styles/Typography';
+import { BodyRegularText, HeaderText } from 'styles/Typography';
 
 const PAGE_SIZE = 7;
 
@@ -54,23 +54,7 @@ const Concert = () => {
         selectedRegion={selectedRegion}
       />
       <ConcertList>
-        {data?.concertThumbnails.map((concert) => (
-          <ConcertItem key={concert.id}>
-            <img alt="posterImg" src={concert.poster} />
-            <Content>
-              <ChipText className="title">{concert.title}</ChipText>
-              <ConcertInfo>
-                <SmallText>{concert.concertHallName}</SmallText>
-                <Place>
-                  <LuCalendar size={16} />
-                  <SmallText>
-                    {concert.stdate} - {concert.eddate}
-                  </SmallText>
-                </Place>
-              </ConcertInfo>
-            </Content>
-          </ConcertItem>
-        ))}
+        {data?.concertThumbnails.map((concert) => <ConcertItem concert={concert} />)}
       </ConcertList>
     </ConcertContainer>
   );
@@ -99,42 +83,6 @@ const ExpectedConcert = styled.div`
 const ConcertList = styled.div`
   width: 100%;
   padding: 2.4rem;
-`;
-
-const ConcertItem = styled.div`
-  display: flex;
-  gap: 1.6rem;
-  padding: 1.2rem 0;
-
-  img {
-    width: 7.5rem;
-    height: 10rem;
-
-    cursor: pointer;
-  }
-`;
-
-const Content = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  cursor: pointer;
-
-  .title {
-    color: ${({ theme }) => theme.colors.dark[100]};
-  }
-`;
-
-const Place = styled.div`
-  display: flex;
-  gap: 0.8rem;
-`;
-
-const ConcertInfo = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.8rem;
-  color: ${({ theme }) => theme.colors.dark[200]};
 `;
 
 export default Concert;

--- a/src/pages/concert/Concert.tsx
+++ b/src/pages/concert/Concert.tsx
@@ -16,7 +16,7 @@ const SORT_DIRECTION = 'DATE';
 
 const Concert = () => {
   const { openModal } = useModalStore(['openModal']);
-  const [selectedRegion, setSelectedRegion] = useState('서울');
+  const [selectedRegion, setSelectedRegion] = useState('전체');
 
   const { data, refetch } = useQuery<Result>({
     queryKey: ['concerts', selectedRegion, SORT_DIRECTION, PAGE_SIZE],
@@ -27,7 +27,6 @@ const Concert = () => {
       return result;
     },
   });
-  console.log(data);
 
   const handleRegionSelect = async (region: string) => {
     setSelectedRegion(region);

--- a/src/pages/concert/components/ConcertItem.tsx
+++ b/src/pages/concert/components/ConcertItem.tsx
@@ -1,0 +1,64 @@
+import styled from '@emotion/styled';
+import { LuCalendar } from 'react-icons/lu';
+
+import type { Concert } from '../type';
+
+import { ChipText, SmallText } from 'styles/Typography';
+
+const ConcertItem = ({ concert }: { concert: Concert }) => {
+  return (
+    <Wrapper key={concert.id}>
+      <img alt="posterImg" src={concert.poster} />
+      <Content>
+        <ChipText className="title">{concert.title}</ChipText>
+        <ConcertInfo>
+          <SmallText>{concert.concertHallName}</SmallText>
+          <Place>
+            <LuCalendar size={16} />
+            <SmallText>
+              {concert.stdate} - {concert.eddate}
+            </SmallText>
+          </Place>
+        </ConcertInfo>
+      </Content>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  padding: 1.2rem 0;
+
+  img {
+    width: 7.5rem;
+    height: 10rem;
+
+    cursor: pointer;
+  }
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  cursor: pointer;
+
+  .title {
+    color: ${({ theme }) => theme.colors.dark[100]};
+  }
+`;
+
+const Place = styled.div`
+  display: flex;
+  gap: 0.8rem;
+`;
+
+const ConcertInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  color: ${({ theme }) => theme.colors.dark[200]};
+`;
+
+export default ConcertItem;

--- a/src/pages/concert/components/FilterChips.tsx
+++ b/src/pages/concert/components/FilterChips.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+
+import { sortValue } from './ListItem';
+import type { FilterCategory } from '../type';
+
+import FilterChip from 'components/chips/FilterChip';
+
+interface FilterChipsProps {
+  selectedRegion: string;
+  selectedDirection: string;
+  handleModalOpen: (title: FilterCategory, handler: (value: string) => void) => void;
+  handleRegionSelect: (value: string) => void;
+  handleDirectionSelect: (value: string) => void;
+}
+
+const FilterChips = ({
+  selectedRegion,
+  selectedDirection,
+  handleModalOpen,
+  handleRegionSelect,
+  handleDirectionSelect,
+}: FilterChipsProps) => {
+  return (
+    <Wrapper>
+      <FilterChip isActive={false} onClick={() => handleModalOpen('지역', handleRegionSelect)}>
+        {selectedRegion}
+      </FilterChip>
+      <FilterChip isActive={false} onClick={() => handleModalOpen('정렬', handleDirectionSelect)}>
+        {sortValue[selectedDirection as keyof typeof sortValue]}
+      </FilterChip>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  gap: 12px;
+  padding: 2.4rem 2.4rem 0 2.4rem;
+`;
+
+export default FilterChips;

--- a/src/pages/concert/components/ListItem.tsx
+++ b/src/pages/concert/components/ListItem.tsx
@@ -27,32 +27,54 @@ const region = [
   '전남',
 ];
 
+export const sortValue = {
+  DATE: '최근 공연순',
+  VIEWS: '인기순',
+};
+
 interface ListItemProps {
-  onRegionSelect: (region: string) => void;
+  title: string;
+  onSelect: (region: string) => void;
 }
 
-const ListItem = ({ onRegionSelect }: ListItemProps) => {
+const ListItem = ({ title, onSelect }: ListItemProps) => {
   const { closeModal } = useModalStore(['closeModal']);
 
   const handleRegionSelect = (selectedRegion: string) => {
-    onRegionSelect(selectedRegion);
+    onSelect(selectedRegion);
     closeModal('bottomSheet', 'list');
+  };
+
+  const handleDirectionSelect = (sortDirection: string) => {
+    onSelect(sortDirection);
+    closeModal('bottomSheet', 'list');
+  };
+
+  const renderItems = () => {
+    if (title === '지역') {
+      return region.map((regionName) => (
+        <Item key={regionName} onClick={() => handleRegionSelect(regionName)}>
+          <BodyRegularText>{regionName}</BodyRegularText>
+        </Item>
+      ));
+    }
+
+    if (title === '정렬') {
+      return Object.entries(sortValue).map(([key, value]) => (
+        <Item key={key} onClick={() => handleDirectionSelect(key)}>
+          <BodyRegularText>{value}</BodyRegularText>
+        </Item>
+      ));
+    }
   };
 
   return (
     <BottomSheet name="list">
       <BottomSheet.Header>
-        <Title>지역</Title>
+        <Title>{title}</Title>
       </BottomSheet.Header>
-
       <BottomSheet.Content>
-        <OptionList>
-          {region.map((regionName) => (
-            <Item key={regionName} onClick={() => handleRegionSelect(regionName)}>
-              <BodyRegularText>{regionName}</BodyRegularText>
-            </Item>
-          ))}
-        </OptionList>
+        <OptionList>{renderItems()}</OptionList>
       </BottomSheet.Content>
     </BottomSheet>
   );

--- a/src/pages/concert/components/ListItem.tsx
+++ b/src/pages/concert/components/ListItem.tsx
@@ -1,0 +1,83 @@
+import styled from '@emotion/styled';
+
+import BottomSheet from 'components/bottomSheet/BottomSheet';
+import { useModalStore } from 'stores';
+import { BodyRegularText } from 'styles/Typography';
+
+const region = [
+  '서울',
+  '경기',
+  '인천',
+  '강원',
+  '세종',
+  '천안',
+  '청주',
+  '대전',
+  '대구',
+  '경북',
+  '부산',
+  '울산',
+  '마산',
+  '창원',
+  '경남',
+  '광주',
+  '전북',
+  '전주',
+  '전남',
+];
+
+interface ListItemProps {
+  onRegionSelect: (region: string) => void;
+}
+
+const ListItem = ({ onRegionSelect }: ListItemProps) => {
+  const { closeModal } = useModalStore(['closeModal']);
+
+  const handleRegionSelect = (selectedRegion: string) => {
+    onRegionSelect(selectedRegion);
+    closeModal('bottomSheet', 'list');
+  };
+
+  return (
+    <BottomSheet name="list">
+      <BottomSheet.Header>
+        <Title>지역</Title>
+      </BottomSheet.Header>
+
+      <BottomSheet.Content>
+        <OptionList>
+          {region.map((regionName) => (
+            <Item key={regionName} onClick={() => handleRegionSelect(regionName)}>
+              <BodyRegularText>{regionName}</BodyRegularText>
+            </Item>
+          ))}
+        </OptionList>
+      </BottomSheet.Content>
+    </BottomSheet>
+  );
+};
+
+const Title = styled.h2`
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+`;
+
+const OptionList = styled.ul`
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+`;
+
+const Item = styled.li`
+  padding: 1.2rem;
+  cursor: pointer;
+  border-radius: 8px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.dark[500]};
+  }
+`;
+
+export default ListItem;

--- a/src/pages/concert/components/ListItem.tsx
+++ b/src/pages/concert/components/ListItem.tsx
@@ -5,6 +5,7 @@ import { useModalStore } from 'stores';
 import { BodyRegularText } from 'styles/Typography';
 
 const region = [
+  '전체',
   '서울',
   '경기',
   '인천',

--- a/src/pages/concert/type.ts
+++ b/src/pages/concert/type.ts
@@ -23,3 +23,5 @@ export interface ConcertsType {
   message: string;
   result: Result;
 }
+
+export type FilterCategory = '지역' | '정렬';

--- a/src/pages/concert/type.ts
+++ b/src/pages/concert/type.ts
@@ -1,0 +1,25 @@
+interface Concert {
+  poster: string;
+  title: string;
+  concertHallName: string;
+  stdate: string;
+  eddate: string;
+  id: number;
+}
+
+interface SearchAfter {
+  0: number;
+  1: string;
+}
+
+export interface Result {
+  concertThumbnails: Concert[];
+  searchAfter: SearchAfter;
+}
+
+export interface ConcertsType {
+  timeStamp: string;
+  code: string;
+  message: string;
+  result: Result;
+}

--- a/src/pages/concert/type.ts
+++ b/src/pages/concert/type.ts
@@ -1,4 +1,4 @@
-interface Concert {
+export interface Concert {
   poster: string;
   title: string;
   concertHallName: string;


### PR DESCRIPTION
## 🔍 PR 개요
메인 페이지의 주요 기능을 구현했습니다!

</br>

## ✨ PR Type
<!--해당 항목에 X를 추가하세요.-->

- [x] 기능 구현
- [ ] 버그 수정
- [ ] 코드 스타일 변경(가독성 향상)
- [ ] 리팩토링(성능 최적화, 모듈화, 중복 코드 제거 등)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] UI/UX 개선
- [ ] 기타:

</br>

## 📋 변경 사항
- 페이지 파일인 `Concert.tsx` 외 page와 관련한 컴포넌트 추가
- endpoint가 살짝 바뀌었습니다
- concert api가 추가되었습니다
- 무한스크롤을 위한 `hook/useIntersectionObserver.tsx `가 추가되었습니다!
- 필터 기능시 사용되는 BottomSheet 컴포넌트에서 사용될 `ListItem.tsx`가 추가되었습니다

</br>

## 🛠 상세 작업 내역
- [x] api 연결
- [x] 필터 기능 추가
- [X] 무한스크롤
- [x] 글쓰기 icon UI 배치

</br>

## ✅ 체크리스트
- [x] 코드가 예상대로 동작하는지 확인
- [x] 관련 테스트가 성공적으로 통과했는지 확인
- [x]  UI/UX 변경 사항이 일관되게 적용되었는지 확인
- [x] 문서가 최신 상태로 유지되었는지 확인 (예: Storybook, README)

</br>


## 🔗 관련 이슈
- Closes #86 

## 🙋🏻‍♀️ 질문 사항
안녕하세요 승민 멘토님! 멘티 정혜인입니다 :) 이번에 기능 구현을 하다 궁금한 점이 아래와같이 생겨 남겨두었습니다! 감사합니다 🙇‍♀️
- pages/concert/Concert.tsx가 공연 메인 페이지일 때, 아이템을 보여주는 <ConcertItem /> 컴포넌트 분리의 범위를 어디까지 해야할지 고민이었습니다..! 현재 ConcertList 자체를 뽑아서 분리해야하는 것이랑요! 
- query 사용 부분에서 아래와 같이 pageParam에서 type 오류 떄문에 type 단언을 해버렸는데요... 개선 방안이 궁금합니다 ㅠㅅㅠ 관련 메서드는 두번째 코드로 첨부해뒀습니다..!
```tsx
// Concert.tsx
type Param = [number, string] | null;
ueryFn: async ({ pageParam }) => {
      const {
        data: { result },
      } = await getConcertList(selectedRegion, selectedDirection, pageParam as Param);
      return result;
    },
```
```tsx
// api/concerts.ts
const getConcertList = async (
  region: string,
  sortDirection: string,
  searchAfter?: [number, string] | null
) => {
  const PAGE_SIZE = 7;
  const params = new URLSearchParams();

  if (region !== '전체') params.append('region', region);

  params.append('sortDirection', sortDirection);
  params.append('PageSize', PAGE_SIZE.toString());

  if (searchAfter) {
    params.append('searchAfter1', searchAfter[0].toString());
    params.append('searchAfter2', searchAfter[1]);
  }

  const response = await publicAxios.get(`${endPoint.GET_CONCERT_LIST}?${params.toString()}`);
  return response;
};

```
- ListItem 컴포넌트에서 title이 '지역', '정렬'에 따라 다른 형태를 띄워주려 했는데요 ,,! RegionListItem 혹은 DirectionListItem 두 개의 컴포넌트로 분리하는게 나았을지 고민이었습니다..!
- URLSearchParams로 param을 덧붙이는 방식이 괜찮은지 궁금합니다..! 더 나은 방법이 있는가 해서요! 예를들어 지역이 전체이면 region을 붙이지 않아야해서 다음과 같은 방법을 택했습니닷 ,,, `api/concerts.ts 에 있는 getConcertList`에 있어요 ㅎㅎ

(머지는 다른 페이지 때문에 해놔도 별도로 피드백 반영해두겠습니다!)
많이 부족한지라 이외에도 눈에 보이는게 있으시다면 피드백 정말 감사히 받겠습니다!! 감사합니다 (´▽`ʃ♡ƪ) 
